### PR TITLE
[Feat] Add support for default Apollo's Types

### DIFF
--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -368,7 +368,11 @@ function processUnionPropertyType(
       [];
   // @ts-ignore
   const supportedType = unionNodes.find(
-      type => Object.values(SupportedTypes).includes(type.kind));
+      type =>
+          Object.keys(SupportedTypes)
+              .map(key => (SupportedTypes as unknown as {[key: string]:
+                                                             number})[key])
+              .includes(type.kind));
   if (supportedType) {
     output[property] =
         generatePrimitive(property, supportedType.kind, options, '');

--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -15,12 +15,12 @@
  */
 import ts from 'typescript';
 
-import { DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT } from '../../lib/constants';
-import { defaultTypeToMock, SupportedPrimitiveTypes } from '../../lib/default-type-to-mock';
-import { fake } from '../../lib/fake';
-import { randomRange } from '../../lib/random-range';
-import { smartProps } from '../../lib/smart-props';
-import { stringify } from '../../lib/stringify';
+import {DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT} from '../../lib/constants';
+import {defaultTypeToMock, supportedPrimitiveTypes} from '../../lib/default-type-to-mock';
+import {fake} from '../../lib/fake';
+import {randomRange} from '../../lib/random-range';
+import {smartProps} from '../../lib/smart-props';
+import {stringify} from '../../lib/stringify';
 
 /**
  * Intermock general options
@@ -46,7 +46,7 @@ export interface Options {
   isOptionalAlwaysEnabled?: boolean;
 }
 
-type OutputType = 'object' | 'json' | 'string';
+type OutputType = 'object'|'json'|'string';
 type SupportedLanguage = 'typescript';
 
 interface JSDoc {
@@ -63,7 +63,7 @@ type TypeCacheRecord = {
   node: ts.Node,
 };
 
-type Output = Record<string | number, {}>;
+type Output = Record<string|number, {}>;
 type Types = Record<string, TypeCacheRecord>;
 
 /**
@@ -75,8 +75,8 @@ type Types = Record<string, TypeCacheRecord>;
  * @param mockType Optional specification of what Faker type to use
  */
 function generatePrimitive(
-  property: string, syntaxType: ts.SyntaxKind, options: Options,
-  mockType?: string) {
+    property: string, syntaxType: ts.SyntaxKind, options: Options,
+    mockType?: string) {
   const smartMockType = smartProps[property];
   const isFixedMode = options.isFixedMode ? options.isFixedMode : false;
 
@@ -100,8 +100,8 @@ function generatePrimitive(
  * @param options Intermock general options object
  */
 function isQuestionToken(
-  questionToken: ts.Token<ts.SyntaxKind.QuestionToken> | undefined,
-  isUnionWithNull: boolean, options: Options) {
+    questionToken: ts.Token<ts.SyntaxKind.QuestionToken>|undefined,
+    isUnionWithNull: boolean, options: Options) {
   if (questionToken || isUnionWithNull) {
     if (options.isFixedMode && !options.isOptionalAlwaysEnabled) {
       return true;
@@ -125,8 +125,8 @@ function isQuestionToken(
  * @param options Intermock general options object
  */
 function processGenericPropertyType(
-  node: ts.PropertySignature, output: Output, property: string,
-  kind: ts.SyntaxKind, mockType: string, options: Options) {
+    node: ts.PropertySignature, output: Output, property: string,
+    kind: ts.SyntaxKind, mockType: string, options: Options) {
   if (node && node.type && ts.isLiteralTypeNode(node.type)) {
     const literal = (node.type as ts.LiteralTypeNode).literal;
     // Boolean Literal
@@ -162,28 +162,29 @@ function processGenericPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processFunctionPropertyType(
-  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
-  sourceFile: ts.SourceFile, options: Options, types: Types) {
+    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
+    sourceFile: ts.SourceFile, options: Options, types: Types) {
   // TODO process args from parameters of function
   const args = '';
   let body = '';
 
-  const funcNode = (ts.isTypeNode(node) ? node : node.type) as ts.FunctionTypeNode;
+  const funcNode =
+      (ts.isTypeNode(node) ? node : node.type) as ts.FunctionTypeNode;
   const returnType = funcNode.type;
 
   switch (returnType.kind) {
     case ts.SyntaxKind.TypeReference:
       const tempBody: Record<string, {}> = {};
       processPropertyTypeReference(
-        node, tempBody, 'body',
-        ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
-        returnType.kind, sourceFile, options, types);
+          node, tempBody, 'body',
+          ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
+          returnType.kind, sourceFile, options, types);
 
       body = `return ${stringify(tempBody['body'])}`;
       break;
     default:
       body = `return ${
-        JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
+          JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
       break;
   }
 
@@ -204,14 +205,14 @@ function processFunctionPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processPropertyTypeReference(
-  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
-  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-  options: Options, types: Types) {
+    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
+    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+    options: Options, types: Types) {
   let normalizedTypeName;
 
   if (typeName.startsWith('Array<') || typeName.startsWith('IterableArray<')) {
     normalizedTypeName =
-      typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
+        typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
   } else {
     normalizedTypeName = typeName;
   }
@@ -219,15 +220,15 @@ function processPropertyTypeReference(
   // TODO: Handle other generics
   if (normalizedTypeName !== typeName) {
     processArrayPropertyType(
-      node, output, property, normalizedTypeName, kind, sourceFile, options,
-      types);
+        node, output, property, normalizedTypeName, kind, sourceFile, options,
+        types);
     return;
   }
 
   if (!types[normalizedTypeName]) {
     throw new Error(`Type '${
-      normalizedTypeName}' is not specified in the provided files but is required for property: '${
-      property}'. Please include it.`);
+        normalizedTypeName}' is not specified in the provided files but is required for property: '${
+        property}'. Please include it.`);
   }
 
   switch ((types[normalizedTypeName] as TypeCacheRecord).kind) {
@@ -236,11 +237,11 @@ function processPropertyTypeReference(
       break;
     default:
       if ((types[normalizedTypeName] as TypeCacheRecord).kind !==
-        (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
+          (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
         const alias = (types[normalizedTypeName] as TypeCacheRecord).aliasedTo;
         const isPrimitiveType = alias === ts.SyntaxKind.StringKeyword ||
-          alias === ts.SyntaxKind.NumberKeyword ||
-          alias === ts.SyntaxKind.BooleanKeyword;
+            alias === ts.SyntaxKind.NumberKeyword ||
+            alias === ts.SyntaxKind.BooleanKeyword;
 
         if (isPrimitiveType) {
           output[property] = generatePrimitive(property, alias, options, '');
@@ -266,8 +267,8 @@ function processPropertyTypeReference(
  * @param options Intermock general options object
  */
 function processJsDocs(
-  node: ts.PropertySignature, output: Output, property: string,
-  jsDocs: JSDoc[], options: Options) {
+    node: ts.PropertySignature, output: Output, property: string,
+    jsDocs: JSDoc[], options: Options) {
   // TODO handle case where we get multiple mock JSDocs or a JSDoc like
   // mockRange for an array. In essence, we are only dealing with
   // primitives now
@@ -311,9 +312,9 @@ function processJsDocs(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processArrayPropertyType(
-  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
-  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-  options: Options, types: Types) {
+    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
+    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+    options: Options, types: Types) {
   typeName = typeName.replace('[', '').replace(']', '');
   output[property] = [];
 
@@ -324,22 +325,22 @@ function processArrayPropertyType(
   }
 
   const isPrimitiveType = kind === ts.SyntaxKind.StringKeyword ||
-    kind === ts.SyntaxKind.BooleanKeyword ||
-    kind === ts.SyntaxKind.NumberKeyword;
+      kind === ts.SyntaxKind.BooleanKeyword ||
+      kind === ts.SyntaxKind.NumberKeyword;
 
   const arrayRange = options.isFixedMode ?
-    FIXED_ARRAY_COUNT :
-    randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
+      FIXED_ARRAY_COUNT :
+      randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
 
   for (let i = 0; i < arrayRange; i++) {
     if (isPrimitiveType) {
       (output[property] as Array<{}>)[i] =
-        generatePrimitive(property, kind, options, '');
+          generatePrimitive(property, kind, options, '');
     } else {
       (output[property] as Array<{}>).push({});
       processFile(
-        sourceFile, (output[property] as Array<{}>)[i], options, types,
-        typeName);
+          sourceFile, (output[property] as Array<{}>)[i], options, types,
+          typeName);
     }
   }
 }
@@ -357,49 +358,49 @@ function processArrayPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processUnionPropertyType(
-  node: ts.PropertySignature, output: Output, property: string,
-  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-  options: Options, types: Types) {
+    node: ts.PropertySignature, output: Output, property: string,
+    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+    options: Options, types: Types) {
   const unionNodes = node && node.type ?
-    (node.type as ts.UnionTypeNode).types as ts.NodeArray<ts.TypeNode> :
-    [];
-  const supportedType = unionNodes.find(
-    type => SupportedPrimitiveTypes[type.kind]);
+      (node.type as ts.UnionTypeNode).types as ts.NodeArray<ts.TypeNode>:
+      [];
+  const supportedType =
+      unionNodes.find(type => supportedPrimitiveTypes[type.kind]);
   if (supportedType) {
     output[property] =
-      generatePrimitive(property, supportedType.kind, options, '');
+        generatePrimitive(property, supportedType.kind, options, '');
     return;
   } else {
     const typeReferenceNode =
-      unionNodes.find(node => node.kind === ts.SyntaxKind.TypeReference) as
-      ts.TypeReferenceNode |
-      undefined;
+        unionNodes.find(node => node.kind === ts.SyntaxKind.TypeReference) as
+            ts.TypeReferenceNode |
+        undefined;
     if (typeReferenceNode) {
       processPropertyTypeReference(
-        typeReferenceNode, output, property,
-        (typeReferenceNode.typeName as ts.Identifier).text,
-        typeReferenceNode.kind, sourceFile, options, types);
+          typeReferenceNode, output, property,
+          (typeReferenceNode.typeName as ts.Identifier).text,
+          typeReferenceNode.kind, sourceFile, options, types);
       return;
     }
     const arrayNode =
-      unionNodes.find(node => node.kind === ts.SyntaxKind.ArrayType) as
-      ts.ArrayTypeNode |
-      undefined;
+        unionNodes.find(node => node.kind === ts.SyntaxKind.ArrayType) as
+            ts.ArrayTypeNode |
+        undefined;
     if (arrayNode) {
       processArrayPropertyType(
-        arrayNode, output, property,
-        `[${
-        ((arrayNode.elementType as ts.TypeReferenceNode).typeName as
-          ts.Identifier)
-          .text}]`,
-        arrayNode.kind, sourceFile, options, types);
+          arrayNode, output, property,
+          `[${
+              ((arrayNode.elementType as ts.TypeReferenceNode).typeName as
+               ts.Identifier)
+                  .text}]`,
+          arrayNode.kind, sourceFile, options, types);
       return;
     }
     const functionNode = unionNodes.find(
-      (node: ts.Node) => node.kind === ts.SyntaxKind.FunctionType);
+        (node: ts.Node) => node.kind === ts.SyntaxKind.FunctionType);
     if (functionNode) {
       processFunctionPropertyType(
-        functionNode, output, property, sourceFile, options, types);
+          functionNode, output, property, sourceFile, options, types);
       return;
     }
 
@@ -409,7 +410,7 @@ function processUnionPropertyType(
 
 function isAnyJsDocs(jsDocs: JSDoc[]) {
   if (jsDocs.length > 0 && jsDocs[0].comment &&
-    jsDocs[0].comment.includes('!mockType')) {
+      jsDocs[0].comment.includes('!mockType')) {
     return true;
   }
 
@@ -426,8 +427,8 @@ function isAnyJsDocs(jsDocs: JSDoc[]) {
  * @param types Top-level types of interfaces/aliases etc.
  */
 function traverseInterfaceMembers(
-  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-  types: Types) {
+    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+    types: Types) {
   if (node.kind !== ts.SyntaxKind.PropertySignature) {
     return;
   }
@@ -447,8 +448,8 @@ function traverseInterfaceMembers(
 
     if (isUnion) {
       isUnionWithNull = !!(node.type as ts.UnionTypeNode)
-        .types.map(type => type.kind)
-        .some(kind => kind === ts.SyntaxKind.NullKeyword);
+                              .types.map(type => type.kind)
+                              .some(kind => kind === ts.SyntaxKind.NullKeyword);
     }
 
     let typeName = '';
@@ -471,26 +472,26 @@ function traverseInterfaceMembers(
     switch (kind) {
       case ts.SyntaxKind.TypeReference:
         processPropertyTypeReference(
-          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-          options, types);
+            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+            options, types);
         break;
       case ts.SyntaxKind.UnionType:
         processUnionPropertyType(
-          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-          options, types);
+            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+            options, types);
         break;
       case ts.SyntaxKind.ArrayType:
         processArrayPropertyType(
-          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-          options, types);
+            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+            options, types);
         break;
       case ts.SyntaxKind.FunctionType:
         processFunctionPropertyType(
-          node, output, property, sourceFile, options, types);
+            node, output, property, sourceFile, options, types);
         break;
       default:
         processGenericPropertyType(
-          node, output, property, kind as ts.SyntaxKind, '', options);
+            node, output, property, kind as ts.SyntaxKind, '', options);
         break;
     }
   };
@@ -507,8 +508,8 @@ function traverseInterfaceMembers(
  * @param property Output property to write to
  */
 function setEnum(
-  sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
-  property: string) {
+    sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
+    property: string) {
   const node: unknown = types[typeName].node;
   if (!node) {
     return;
@@ -526,7 +527,7 @@ function setEnum(
         break;
       case ts.SyntaxKind.StringLiteral:
         output[property] =
-          selectedMember.initializer.getText().replace(/\'/g, '');
+            selectedMember.initializer.getText().replace(/\'/g, '');
         break;
       default:
         break;
@@ -549,8 +550,8 @@ function setEnum(
  * @param path Optional specific path to write to on the output object
  */
 function traverseInterface(
-  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-  types: Types, propToTraverse?: string, path?: string) {
+    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+    types: Types, propToTraverse?: string, path?: string) {
   if (path) {
     output[path] = {};
     output = output[path];
@@ -573,16 +574,16 @@ function traverseInterface(
 
         if (!types[extensionType]) {
           throw new Error(`Type '${
-            extensionType}' is not specified in the provided files but is required for interface extension of: '${
-            (node as ts.InterfaceDeclaration)
-              .name.text}'. Please include it.`);
+              extensionType}' is not specified in the provided files but is required for interface extension of: '${
+              (node as ts.InterfaceDeclaration)
+                  .name.text}'. Please include it.`);
         }
 
         const extensionNode = types[extensionType].node;
         let extensionOutput: Output = {};
         traverseInterface(
-          extensionNode, extensionOutput, sourceFile, options, types,
-          propToTraverse, path);
+            extensionNode, extensionOutput, sourceFile, options, types,
+            propToTraverse, path);
 
         extensionOutput = extensionOutput[extensionType];
         extensions.push(extensionOutput);
@@ -600,8 +601,8 @@ function traverseInterface(
   // TODO given a range of interfaces to generate, add to array. If 1
   // then just return an object
   node.forEachChild(
-    child =>
-      traverseInterfaceMembers(child, output, sourceFile, options, types));
+      child =>
+          traverseInterfaceMembers(child, output, sourceFile, options, types));
 }
 
 function isSpecificInterface(name: string, options: Options) {
@@ -627,8 +628,8 @@ function isSpecificInterface(name: string, options: Options) {
  *     interface
  */
 function processFile(
-  sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
-  propToTraverse?: string) {
+    sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
+    propToTraverse?: string) {
   const processNode = (node: ts.Node) => {
     switch (node.kind) {
       case ts.SyntaxKind.InterfaceDeclaration:
@@ -644,7 +645,7 @@ function processFile(
         if (propToTraverse) {
           if (p === propToTraverse) {
             traverseInterface(
-              node, output, sourceFile, options, types, propToTraverse);
+                node, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(node, output, sourceFile, options, types);
@@ -661,11 +662,11 @@ function processFile(
         if (propToTraverse) {
           if (path === propToTraverse) {
             traverseInterface(
-              type, output, sourceFile, options, types, propToTraverse);
+                type, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(
-            type, output, sourceFile, options, types, undefined, path);
+              type, output, sourceFile, options, types, undefined, path);
         }
         break;
 
@@ -685,11 +686,11 @@ function processFile(
  *
  * @param sourceFile TypeScript AST object compiled from file data
  */
-function gatherTypes(sourceFile: ts.SourceFile | ts.ModuleBlock) {
+function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
   const types: Types = {};
   let modulePrefix = '';
 
-  const processNode = (node: ts.Node | ts.ModuleBlock) => {
+  const processNode = (node: ts.Node|ts.ModuleBlock) => {
     const name = (node as ts.DeclarationStatement).name;
     const text = name ? name.text : '';
 
@@ -712,9 +713,9 @@ function gatherTypes(sourceFile: ts.SourceFile | ts.ModuleBlock) {
     }
 
     if (modulePrefix) {
-      types[`${modulePrefix}.${text}`] = { kind: node.kind, aliasedTo, node };
+      types[`${modulePrefix}.${text}`] = {kind: node.kind, aliasedTo, node};
     }
-    types[text] = { kind: node.kind, aliasedTo, node };
+    types[text] = {kind: node.kind, aliasedTo, node};
 
     ts.forEachChild(node, processNode);
   };
@@ -731,7 +732,7 @@ function gatherTypes(sourceFile: ts.SourceFile | ts.ModuleBlock) {
  * @param output The object outputted by Intermock after all types are mocked
  * @param options Intermock general options object
  */
-function formatOutput(output: Output, options: Options): string | Output {
+function formatOutput(output: Output, options: Options): string|Output {
   switch (options.output) {
     case 'json':
       return JSON.stringify(output);
@@ -764,15 +765,15 @@ export function mock(options: Options) {
 
   fileContents.forEach((f) => {
     types = Object.assign(
-      {}, types,
-      gatherTypes(
-        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
+        {}, types,
+        gatherTypes(
+            ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
   });
 
   fileContents.forEach((f) => {
     processFile(
-      ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
-      options, types);
+        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
+        options, types);
   });
 
   return formatOutput(output, options);

--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import ts, {ArrayTypeNode, FunctionTypeNode, isArrayTypeNode, isFunctionTypeNode, isTypeNode, LiteralTypeNode, NumericLiteral, TypeReferenceNode} from 'typescript';
+import ts, { ArrayTypeNode, FunctionTypeNode, isTypeNode, NumericLiteral, TypeReferenceNode, isLiteralTypeNode } from 'typescript';
 
-import {DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT} from '../../lib/constants';
-import {defaultTypeToMock, SupportedTypes} from '../../lib/default-type-to-mock';
-import {fake} from '../../lib/fake';
-import {randomRange} from '../../lib/random-range';
-import {smartProps} from '../../lib/smart-props';
-import {stringify} from '../../lib/stringify';
+import { DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT } from '../../lib/constants';
+import { defaultTypeToMock, SupportedPrimitiveTypes } from '../../lib/default-type-to-mock';
+import { fake } from '../../lib/fake';
+import { randomRange } from '../../lib/random-range';
+import { smartProps } from '../../lib/smart-props';
+import { stringify } from '../../lib/stringify';
 
 /**
  * Intermock general options
@@ -46,7 +46,7 @@ export interface Options {
   isOptionalAlwaysEnabled?: boolean;
 }
 
-type OutputType = 'object'|'json'|'string';
+type OutputType = 'object' | 'json' | 'string';
 type SupportedLanguage = 'typescript';
 
 interface JSDoc {
@@ -75,8 +75,8 @@ type Types = Record<string, TypeCacheRecord>;
  * @param mockType Optional specification of what Faker type to use
  */
 function generatePrimitive(
-    property: string, syntaxType: ts.SyntaxKind, options: Options,
-    mockType?: string) {
+  property: string, syntaxType: ts.SyntaxKind, options: Options,
+  mockType?: string) {
   const smartMockType = smartProps[property];
   const isFixedMode = options.isFixedMode ? options.isFixedMode : false;
 
@@ -100,8 +100,8 @@ function generatePrimitive(
  * @param options Intermock general options object
  */
 function isQuestionToken(
-    questionToken: ts.Token<ts.SyntaxKind.QuestionToken>|undefined,
-    isUnionWithNull: boolean, options: Options) {
+  questionToken: ts.Token<ts.SyntaxKind.QuestionToken> | undefined,
+  isUnionWithNull: boolean, options: Options) {
   if (questionToken || isUnionWithNull) {
     if (options.isFixedMode && !options.isOptionalAlwaysEnabled) {
       return true;
@@ -125,11 +125,9 @@ function isQuestionToken(
  * @param options Intermock general options object
  */
 function processGenericPropertyType(
-    node: ts.PropertySignature, output: Output, property: string,
-    kind: ts.SyntaxKind, mockType: string, options: Options) {
-  // @ts-ignore
-  if (node && node.type && node.type.literal &&
-      node.type.kind === ts.SyntaxKind.LiteralType) {
+  node: ts.PropertySignature, output: Output, property: string,
+  kind: ts.SyntaxKind, mockType: string, options: Options) {
+  if (node && node.type && isLiteralTypeNode(node.type)) {
     const literal = (node.type as ts.LiteralTypeNode).literal;
     // Boolean Literal
     if (literal.kind === ts.SyntaxKind.TrueKeyword) {
@@ -164,8 +162,8 @@ function processGenericPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processFunctionPropertyType(
-    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
-    sourceFile: ts.SourceFile, options: Options, types: Types) {
+  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
+  sourceFile: ts.SourceFile, options: Options, types: Types) {
   // TODO process args from parameters of function
   const args = '';
   let body = '';
@@ -177,15 +175,15 @@ function processFunctionPropertyType(
     case ts.SyntaxKind.TypeReference:
       const tempBody: Record<string, {}> = {};
       processPropertyTypeReference(
-          node, tempBody, 'body',
-          ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
-          returnType.kind, sourceFile, options, types);
+        node, tempBody, 'body',
+        ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
+        returnType.kind, sourceFile, options, types);
 
       body = `return ${stringify(tempBody['body'])}`;
       break;
     default:
       body = `return ${
-          JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
+        JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
       break;
   }
 
@@ -206,14 +204,14 @@ function processFunctionPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processPropertyTypeReference(
-    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
-    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-    options: Options, types: Types) {
+  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
   let normalizedTypeName;
 
   if (typeName.startsWith('Array<') || typeName.startsWith('IterableArray<')) {
     normalizedTypeName =
-        typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
+      typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
   } else {
     normalizedTypeName = typeName;
   }
@@ -221,15 +219,15 @@ function processPropertyTypeReference(
   // TODO: Handle other generics
   if (normalizedTypeName !== typeName) {
     processArrayPropertyType(
-        node, output, property, normalizedTypeName, kind, sourceFile, options,
-        types);
+      node, output, property, normalizedTypeName, kind, sourceFile, options,
+      types);
     return;
   }
 
   if (!types[normalizedTypeName]) {
     throw new Error(`Type '${
-        normalizedTypeName}' is not specified in the provided files but is required for property: '${
-        property}'. Please include it.`);
+      normalizedTypeName}' is not specified in the provided files but is required for property: '${
+      property}'. Please include it.`);
   }
 
   switch ((types[normalizedTypeName] as TypeCacheRecord).kind) {
@@ -238,11 +236,11 @@ function processPropertyTypeReference(
       break;
     default:
       if ((types[normalizedTypeName] as TypeCacheRecord).kind !==
-          (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
+        (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
         const alias = (types[normalizedTypeName] as TypeCacheRecord).aliasedTo;
         const isPrimitiveType = alias === ts.SyntaxKind.StringKeyword ||
-            alias === ts.SyntaxKind.NumberKeyword ||
-            alias === ts.SyntaxKind.BooleanKeyword;
+          alias === ts.SyntaxKind.NumberKeyword ||
+          alias === ts.SyntaxKind.BooleanKeyword;
 
         if (isPrimitiveType) {
           output[property] = generatePrimitive(property, alias, options, '');
@@ -268,8 +266,8 @@ function processPropertyTypeReference(
  * @param options Intermock general options object
  */
 function processJsDocs(
-    node: ts.PropertySignature, output: Output, property: string,
-    jsDocs: JSDoc[], options: Options) {
+  node: ts.PropertySignature, output: Output, property: string,
+  jsDocs: JSDoc[], options: Options) {
   // TODO handle case where we get multiple mock JSDocs or a JSDoc like
   // mockRange for an array. In essence, we are only dealing with
   // primitives now
@@ -313,9 +311,9 @@ function processJsDocs(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processArrayPropertyType(
-    node: ts.PropertySignature|ts.TypeNode, output: Output, property: string,
-    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-    options: Options, types: Types) {
+  node: ts.PropertySignature | ts.TypeNode, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
   typeName = typeName.replace('[', '').replace(']', '');
   output[property] = [];
 
@@ -326,28 +324,28 @@ function processArrayPropertyType(
   }
 
   const isPrimitiveType = kind === ts.SyntaxKind.StringKeyword ||
-      kind === ts.SyntaxKind.BooleanKeyword ||
-      kind === ts.SyntaxKind.NumberKeyword;
+    kind === ts.SyntaxKind.BooleanKeyword ||
+    kind === ts.SyntaxKind.NumberKeyword;
 
   const arrayRange = options.isFixedMode ?
-      FIXED_ARRAY_COUNT :
-      randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
+    FIXED_ARRAY_COUNT :
+    randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
 
   for (let i = 0; i < arrayRange; i++) {
     if (isPrimitiveType) {
       (output[property] as Array<{}>)[i] =
-          generatePrimitive(property, kind, options, '');
+        generatePrimitive(property, kind, options, '');
     } else {
       (output[property] as Array<{}>).push({});
       processFile(
-          sourceFile, (output[property] as Array<{}>)[i], options, types,
-          typeName);
+        sourceFile, (output[property] as Array<{}>)[i], options, types,
+        typeName);
     }
   }
 }
 
 /**
- * Process an array definition.
+ * Process a union property.
  *
  * @param node Node being processed
  * @param output The object outputted by Intermock after all types are mocked
@@ -359,58 +357,49 @@ function processArrayPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processUnionPropertyType(
-    node: ts.PropertySignature, output: Output, property: string,
-    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-    options: Options, types: Types) {
-  // @ts-ignore
+  node: ts.PropertySignature, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
   const unionNodes = node && node.type ?
-      (node.type as ts.UnionTypeNode).types as ts.NodeArray<ts.TypeNode>:
-      [];
-  // @ts-ignore
+    (node.type as ts.UnionTypeNode).types as ts.NodeArray<ts.TypeNode> :
+    [];
   const supportedType = unionNodes.find(
-      type =>
-          Object.keys(SupportedTypes)
-              .map(key => (SupportedTypes as unknown as {[key: string]:
-                                                             number})[key])
-              .includes(type.kind));
+    type => SupportedPrimitiveTypes[type.kind]);
   if (supportedType) {
     output[property] =
-        generatePrimitive(property, supportedType.kind, options, '');
+      generatePrimitive(property, supportedType.kind, options, '');
     return;
   } else {
-    // @ts-ignore
     const typeReferenceNode =
-        unionNodes.find(node => node.kind === ts.SyntaxKind.TypeReference) as
-            TypeReferenceNode |
-        undefined;
+      unionNodes.find(node => node.kind === ts.SyntaxKind.TypeReference) as
+      TypeReferenceNode |
+      undefined;
     if (typeReferenceNode) {
       processPropertyTypeReference(
-          typeReferenceNode, output, property,
-          (typeReferenceNode.typeName as ts.Identifier).text,
-          typeReferenceNode.kind, sourceFile, options, types);
+        typeReferenceNode, output, property,
+        (typeReferenceNode.typeName as ts.Identifier).text,
+        typeReferenceNode.kind, sourceFile, options, types);
       return;
     }
-    // @ts-ignore
     const arrayNode =
-        unionNodes.find(node => node.kind === ts.SyntaxKind.ArrayType) as
-            ArrayTypeNode |
-        undefined;
+      unionNodes.find(node => node.kind === ts.SyntaxKind.ArrayType) as
+      ArrayTypeNode |
+      undefined;
     if (arrayNode) {
       processArrayPropertyType(
-          arrayNode, output, property,
-          `[${
-              ((arrayNode.elementType as TypeReferenceNode).typeName as
-               ts.Identifier)
-                  .text}]`,
-          arrayNode.kind, sourceFile, options, types);
+        arrayNode, output, property,
+        `[${
+        ((arrayNode.elementType as TypeReferenceNode).typeName as
+          ts.Identifier)
+          .text}]`,
+        arrayNode.kind, sourceFile, options, types);
       return;
     }
-    // @ts-ignore
     const functionNode = unionNodes.find(
-        (node: ts.Node) => node.kind === ts.SyntaxKind.FunctionType);
+      (node: ts.Node) => node.kind === ts.SyntaxKind.FunctionType);
     if (functionNode) {
       processFunctionPropertyType(
-          functionNode, output, property, sourceFile, options, types);
+        functionNode, output, property, sourceFile, options, types);
       return;
     }
 
@@ -420,7 +409,7 @@ function processUnionPropertyType(
 
 function isAnyJsDocs(jsDocs: JSDoc[]) {
   if (jsDocs.length > 0 && jsDocs[0].comment &&
-      jsDocs[0].comment.includes('!mockType')) {
+    jsDocs[0].comment.includes('!mockType')) {
     return true;
   }
 
@@ -437,8 +426,8 @@ function isAnyJsDocs(jsDocs: JSDoc[]) {
  * @param types Top-level types of interfaces/aliases etc.
  */
 function traverseInterfaceMembers(
-    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-    types: Types) {
+  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+  types: Types) {
   if (node.kind !== ts.SyntaxKind.PropertySignature) {
     return;
   }
@@ -458,8 +447,8 @@ function traverseInterfaceMembers(
 
     if (isUnion) {
       isUnionWithNull = !!(node.type as ts.UnionTypeNode)
-                              .types.map(type => type.kind)
-                              .some(kind => kind === ts.SyntaxKind.NullKeyword);
+        .types.map(type => type.kind)
+        .some(kind => kind === ts.SyntaxKind.NullKeyword);
     }
 
     let typeName = '';
@@ -482,26 +471,26 @@ function traverseInterfaceMembers(
     switch (kind) {
       case ts.SyntaxKind.TypeReference:
         processPropertyTypeReference(
-            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-            options, types);
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
         break;
       case ts.SyntaxKind.UnionType:
         processUnionPropertyType(
-            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-            options, types);
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
         break;
       case ts.SyntaxKind.ArrayType:
         processArrayPropertyType(
-            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-            options, types);
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
         break;
       case ts.SyntaxKind.FunctionType:
         processFunctionPropertyType(
-            node, output, property, sourceFile, options, types);
+          node, output, property, sourceFile, options, types);
         break;
       default:
         processGenericPropertyType(
-            node, output, property, kind as ts.SyntaxKind, '', options);
+          node, output, property, kind as ts.SyntaxKind, '', options);
         break;
     }
   };
@@ -518,8 +507,8 @@ function traverseInterfaceMembers(
  * @param property Output property to write to
  */
 function setEnum(
-    sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
-    property: string) {
+  sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
+  property: string) {
   const node: unknown = types[typeName].node;
   if (!node) {
     return;
@@ -537,7 +526,7 @@ function setEnum(
         break;
       case ts.SyntaxKind.StringLiteral:
         output[property] =
-            selectedMember.initializer.getText().replace(/\'/g, '');
+          selectedMember.initializer.getText().replace(/\'/g, '');
         break;
       default:
         break;
@@ -560,8 +549,8 @@ function setEnum(
  * @param path Optional specific path to write to on the output object
  */
 function traverseInterface(
-    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-    types: Types, propToTraverse?: string, path?: string) {
+  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+  types: Types, propToTraverse?: string, path?: string) {
   if (path) {
     output[path] = {};
     output = output[path];
@@ -584,16 +573,16 @@ function traverseInterface(
 
         if (!types[extensionType]) {
           throw new Error(`Type '${
-              extensionType}' is not specified in the provided files but is required for interface extension of: '${
-              (node as ts.InterfaceDeclaration)
-                  .name.text}'. Please include it.`);
+            extensionType}' is not specified in the provided files but is required for interface extension of: '${
+            (node as ts.InterfaceDeclaration)
+              .name.text}'. Please include it.`);
         }
 
         const extensionNode = types[extensionType].node;
         let extensionOutput: Output = {};
         traverseInterface(
-            extensionNode, extensionOutput, sourceFile, options, types,
-            propToTraverse, path);
+          extensionNode, extensionOutput, sourceFile, options, types,
+          propToTraverse, path);
 
         extensionOutput = extensionOutput[extensionType];
         extensions.push(extensionOutput);
@@ -611,8 +600,8 @@ function traverseInterface(
   // TODO given a range of interfaces to generate, add to array. If 1
   // then just return an object
   node.forEachChild(
-      child =>
-          traverseInterfaceMembers(child, output, sourceFile, options, types));
+    child =>
+      traverseInterfaceMembers(child, output, sourceFile, options, types));
 }
 
 function isSpecificInterface(name: string, options: Options) {
@@ -638,8 +627,8 @@ function isSpecificInterface(name: string, options: Options) {
  *     interface
  */
 function processFile(
-    sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
-    propToTraverse?: string) {
+  sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
+  propToTraverse?: string) {
   const processNode = (node: ts.Node) => {
     switch (node.kind) {
       case ts.SyntaxKind.InterfaceDeclaration:
@@ -655,7 +644,7 @@ function processFile(
         if (propToTraverse) {
           if (p === propToTraverse) {
             traverseInterface(
-                node, output, sourceFile, options, types, propToTraverse);
+              node, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(node, output, sourceFile, options, types);
@@ -672,11 +661,11 @@ function processFile(
         if (propToTraverse) {
           if (path === propToTraverse) {
             traverseInterface(
-                type, output, sourceFile, options, types, propToTraverse);
+              type, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(
-              type, output, sourceFile, options, types, undefined, path);
+            type, output, sourceFile, options, types, undefined, path);
         }
         break;
 
@@ -696,11 +685,11 @@ function processFile(
  *
  * @param sourceFile TypeScript AST object compiled from file data
  */
-function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
+function gatherTypes(sourceFile: ts.SourceFile | ts.ModuleBlock) {
   const types: Types = {};
   let modulePrefix = '';
 
-  const processNode = (node: ts.Node|ts.ModuleBlock) => {
+  const processNode = (node: ts.Node | ts.ModuleBlock) => {
     const name = (node as ts.DeclarationStatement).name;
     const text = name ? name.text : '';
 
@@ -723,9 +712,9 @@ function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
     }
 
     if (modulePrefix) {
-      types[`${modulePrefix}.${text}`] = {kind: node.kind, aliasedTo, node};
+      types[`${modulePrefix}.${text}`] = { kind: node.kind, aliasedTo, node };
     }
-    types[text] = {kind: node.kind, aliasedTo, node};
+    types[text] = { kind: node.kind, aliasedTo, node };
 
     ts.forEachChild(node, processNode);
   };
@@ -742,7 +731,7 @@ function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
  * @param output The object outputted by Intermock after all types are mocked
  * @param options Intermock general options object
  */
-function formatOutput(output: Output, options: Options): string|Output {
+function formatOutput(output: Output, options: Options): string | Output {
   switch (options.output) {
     case 'json':
       return JSON.stringify(output);
@@ -775,15 +764,15 @@ export function mock(options: Options) {
 
   fileContents.forEach((f) => {
     types = Object.assign(
-        {}, types,
-        gatherTypes(
-            ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
+      {}, types,
+      gatherTypes(
+        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
   });
 
   fileContents.forEach((f) => {
     processFile(
-        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
-        options, types);
+      ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
+      options, types);
   });
 
   return formatOutput(output, options);

--- a/src/lib/default-type-to-mock.ts
+++ b/src/lib/default-type-to-mock.ts
@@ -16,6 +16,14 @@
 import ts from 'typescript';
 import {fake} from './fake';
 
+export enum SupportedTypes {
+  NumberKeyword = ts.SyntaxKind.NumberKeyword,
+  StringKeyword = ts.SyntaxKind.StringKeyword,
+  BooleanKeyword = ts.SyntaxKind.BooleanKeyword,
+  ObjectKeyword = ts.SyntaxKind.ObjectKeyword,
+  AnyKeyword = ts.SyntaxKind.AnyKeyword,
+}
+
 /* tslint:disable */
 export const defaultTypeToMock: {
   [index: number]: (isFixedMode: boolean) => string | number | boolean | object

--- a/src/lib/default-type-to-mock.ts
+++ b/src/lib/default-type-to-mock.ts
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 import ts from 'typescript';
-import { fake } from './fake';
+import {fake} from './fake';
 
-export const SupportedPrimitiveTypes: { [key: string]: boolean } = {
+export const supportedPrimitiveTypes: {[key: string]: boolean} = {
   [ts.SyntaxKind.NumberKeyword]: true,
   [ts.SyntaxKind.StringKeyword]: true,
   [ts.SyntaxKind.BooleanKeyword]: true,
   [ts.SyntaxKind.ObjectKeyword]: true,
   [ts.SyntaxKind.AnyKeyword]: true,
-}
+};
 
 /* tslint:disable */
 export const defaultTypeToMock: {
   [index: number]: (isFixedMode: boolean) => string | number | boolean | object
 } = {
   [ts.SyntaxKind.NumberKeyword]: (isFixedMode = false) =>
-    parseInt(fake('random.number', isFixedMode) as string, 10),
+      parseInt(fake('random.number', isFixedMode) as string, 10),
   [ts.SyntaxKind.StringKeyword]: (isFixedMode = false) =>
-    fake('lorem.text', isFixedMode),
+      fake('lorem.text', isFixedMode),
   [ts.SyntaxKind.BooleanKeyword]: (isFixedMode = false) =>
-    JSON.parse(fake('random.boolean', isFixedMode) as string),
+      JSON.parse(fake('random.boolean', isFixedMode) as string),
   [ts.SyntaxKind.ObjectKeyword]: (isFixedMode = false) => {
     return {}
   },

--- a/src/lib/default-type-to-mock.ts
+++ b/src/lib/default-type-to-mock.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 import ts from 'typescript';
-import {fake} from './fake';
+import { fake } from './fake';
 
-export enum SupportedTypes {
-  NumberKeyword = ts.SyntaxKind.NumberKeyword,
-  StringKeyword = ts.SyntaxKind.StringKeyword,
-  BooleanKeyword = ts.SyntaxKind.BooleanKeyword,
-  ObjectKeyword = ts.SyntaxKind.ObjectKeyword,
-  AnyKeyword = ts.SyntaxKind.AnyKeyword,
+export const SupportedPrimitiveTypes: { [key: string]: boolean } = {
+  [ts.SyntaxKind.NumberKeyword]: true,
+  [ts.SyntaxKind.StringKeyword]: true,
+  [ts.SyntaxKind.BooleanKeyword]: true,
+  [ts.SyntaxKind.ObjectKeyword]: true,
+  [ts.SyntaxKind.AnyKeyword]: true,
 }
 
 /* tslint:disable */
@@ -29,11 +29,11 @@ export const defaultTypeToMock: {
   [index: number]: (isFixedMode: boolean) => string | number | boolean | object
 } = {
   [ts.SyntaxKind.NumberKeyword]: (isFixedMode = false) =>
-      parseInt(fake('random.number', isFixedMode) as string, 10),
+    parseInt(fake('random.number', isFixedMode) as string, 10),
   [ts.SyntaxKind.StringKeyword]: (isFixedMode = false) =>
-      fake('lorem.text', isFixedMode),
+    fake('lorem.text', isFixedMode),
   [ts.SyntaxKind.BooleanKeyword]: (isFixedMode = false) =>
-      JSON.parse(fake('random.boolean', isFixedMode) as string),
+    JSON.parse(fake('random.boolean', isFixedMode) as string),
   [ts.SyntaxKind.ObjectKeyword]: (isFixedMode = false) => {
     return {}
   },

--- a/test/ts/mock.spec.ts
+++ b/test/ts/mock.spec.ts
@@ -35,6 +35,7 @@ import {expectedNested} from './test-data/nestedSingle';
 import {expectedOptional1, expectedOptional2} from './test-data/optional';
 import {expectedSpecificInterface} from './test-data/specificInterfaces';
 import {expectedTypeAlias} from './test-data/typeAlias';
+import {expectedUnion} from './test-data/unions';
 
 async function runTestCase(
     file: string, outputProp: string, expected: unknown, options?: Options) {
@@ -102,6 +103,28 @@ describe('Intermock TypeScript: Mock tests', () => {
     return runTestCase(
         `${__dirname}/test-data/enum.ts`, 'Person', expectedEnum.Person);
   });
+
+  it('should generate mock for unions - with generic types', () => {
+    return runTestCase(
+        `${__dirname}/test-data/unions.ts`, 'Account', expectedUnion.Account);
+  });
+
+  it('should generate mock for unions - with type references', () => {
+    return runTestCase(
+        `${__dirname}/test-data/unions.ts`, 'Person', expectedUnion.Person);
+  });
+
+  it('should generate mock for unions - with arrays', () => {
+    return runTestCase(
+        `${__dirname}/test-data/unions.ts`, 'Pack', expectedUnion.Pack);
+  });
+
+  it('should generate mock for unions - for null option to work like question mark',
+     async () => {
+       return runTestCase(
+           `${__dirname}/test-data/unions.ts`, 'LonelyHuman',
+           expectedUnion.LonelyHuman);
+     });
 
   it('should generate mock for basic arrays', () => {
     return runTestCase(

--- a/test/ts/test-data/flat.ts
+++ b/test/ts/test-data/flat.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 interface FlatInterface {
-  id: 5, type: 'person', wantsFries: true, wantsChocolate: false, name: string;
+  id: 5;
+  type: 'person';
+  wantsFries: true;
+  wantsChocolate: false;
+  name: string;
   age: number;
   isCool: boolean;
 }

--- a/test/ts/test-data/flat.ts
+++ b/test/ts/test-data/flat.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 interface FlatInterface {
-  name: string;
+  id: 5, type: 'person', wantsFries: true, wantsChocolate: false, name: string;
   age: number;
   isCool: boolean;
 }
@@ -22,5 +22,9 @@ interface FlatInterface {
 export const expectedFlat = {
   name: 'Natasha Jacobs',
   age: 86924,
-  isCool: true
+  isCool: true,
+  type: 'person',
+  id: 5,
+  wantsFries: true,
+  wantsChocolate: false,
 };

--- a/test/ts/test-data/unions.ts
+++ b/test/ts/test-data/unions.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface Dog {
+  name: string;
+  owner: string;
+}
+
+interface Cat {
+  name: string;
+  owns: string;
+}
+
+interface Person {
+  name: string;
+  age: number;
+  bestFriend: Dog|Cat;
+}
+
+interface Pack {
+  id: string;
+  dogs: Dog[]|Cat[];
+}
+
+interface Account {
+  id: string;
+  lastDeposit: number|string;
+}
+
+export interface LonelyHuman {
+  name: string;
+  bestFriend: Dog|null;
+}
+
+// TODO: test union with
+// functions: currently I don't know how to make a Union for functions (if the
+// first union option is a function, then the `|` character gets applied to the
+// return type)
+
+export const expectedUnion = {
+  Person: {
+    name: 'Natasha Jacobs',
+    age: 86924,
+    bestFriend: {
+      name: 'Natasha Jacobs',
+      owner:
+          'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.'
+    }
+  },
+  Pack: {
+    id: 'bfc8cb62-c6ce-4194-a2a5-499320b837eb',
+    dogs: [
+      {
+        name: 'Natasha Jacobs',
+        owner:
+            'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.'
+      },
+      {
+        name: 'Natasha Jacobs',
+        owner:
+            'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.'
+      },
+      {
+        name: 'Natasha Jacobs',
+        owner:
+            'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.'
+      }
+    ]
+  },
+  Account: {
+    id: 'bfc8cb62-c6ce-4194-a2a5-499320b837eb',
+    lastDeposit: 86924,
+  },
+  LonelyHuman: {
+    name: 'Natasha Jacobs',
+  }
+};


### PR DESCRIPTION
## Purpose
Adding support for Unions and Literals, both of which are used a lot on the apollo:codegen tool

This intends to include all the most common kinds that apollo codegen generates, so that by using them together we can create graphql mocks