### PR TITLE
Support literal union types

### DIFF
--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -567,6 +567,13 @@ function processUnionPropertyType(
           options, types);
       return;
     }
+    const literalNode = unionNodes.every(
+      (node: ts.Node) => node.kind === ts.SyntaxKind.LiteralType);
+    if (literalNode) {
+      const literalIndex = options.isFixedMode ? 0 : randomRange(0, unionNodes.length - 1);
+      output[property] = getLiteralTypeValue(unionNodes[literalIndex] as ts.LiteralTypeNode);
+      return;
+    }
 
     throw Error(`Unsupported Union option type ${property}: ${typeName}`);
   }

--- a/test/ts/mock.spec.ts
+++ b/test/ts/mock.spec.ts
@@ -122,6 +122,11 @@ describe('Intermock TypeScript: Mock tests', () => {
         `${__dirname}/test-data/unions.ts`, 'Pack', expectedUnion.Pack);
   });
 
+  it('should generate mock for unions - with literals', () => {
+    return runTestCase(
+        `${__dirname}/test-data/unions.ts`, 'Book', expectedUnion.Book);
+  });
+
   it('should generate mock for unions - for null option to work like question mark',
      () => {
        return runTestCase(

--- a/test/ts/test-data/unions.ts
+++ b/test/ts/test-data/unions.ts
@@ -39,6 +39,12 @@ interface Account {
   lastDeposit: number|string;
 }
 
+
+interface Book {
+  title: string,
+  color: 'red' | 'blue' | 'yellow';
+}
+
 export interface LonelyHuman {
   name: string;
   bestFriend: Dog|null;
@@ -85,5 +91,9 @@ export const expectedUnion = {
   },
   LonelyHuman: {
     name: 'Natasha Jacobs',
+  },
+  Book: {
+    title: 'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.',
+    color: 'red'
   }
 };


### PR DESCRIPTION
Adds support for unioned literals. 

```
 color: 'red' | 'blue' | 'yellow';
```
Will output one of the possible values randomly. In fixed mode, it will choose the first literal.

This is written to only support union types that are exclusively literals. Mixed types are not supported: 
```
// Will NOT work
color: 'red' | 'yellow' | string;
```