### PR TITLE
Updates to improve json output support

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ const optionDefinitions = [
   {name: 'interfaces', alias: 'i', type: String, multiple: true},
   {name: 'help', alias: 'h', type: Boolean},
   {name: 'fixed', alias: 'x', type: Boolean},
+  {name: 'outputFormat', alias: 'o', type: String},
 ];
 
 const instructions = [
@@ -55,6 +56,11 @@ const instructions = [
         description: 'Interface files to generate fake data from',
       },
       {
+        name: 'outputFormat',
+        typeLabel: 'example: json',
+        description: 'Format to use for output. Can be string, json or object',
+      },
+      {
         name: 'help',
         description: 'Print this usage guide.',
       }
@@ -68,6 +74,7 @@ interface Options {
   language: string;
   interfaces: string[];
   fixed: boolean;
+  outputFormat: string;
 }
 
 function isWelcomeMessageNeeded(options: Options) {
@@ -93,16 +100,18 @@ function main() {
 
   const isFixedMode = options.fixed;
   const interfaces = options.interfaces;
+  const output = options.outputFormat;
 
   return readFiles(options.files).then((files) => {
     try {
-      const output = IntermockTS({
+      const result = IntermockTS({
         files,
         interfaces,
         isFixedMode,
+        output,
       });
 
-      console.dir(output, {depth: null, colors: true});
+      console.log(result);
     } catch (err) {
       console.log(err.message);
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,7 +16,7 @@
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 
-import {mock as IntermockTS} from '../lang/ts/intermock';
+import {mock as IntermockTS, OutputType} from '../lang/ts/intermock';
 import {readFiles} from '../lib/read-files';
 
 const optionDefinitions = [
@@ -74,7 +74,7 @@ interface Options {
   language: string;
   interfaces: string[];
   fixed: boolean;
-  outputFormat: string;
+  outputFormat: OutputType;
 }
 
 function isWelcomeMessageNeeded(options: Options) {

--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -40,15 +40,13 @@ export interface Options {
 
   // One of object|json|string. Strings have their object's functions
   // stringified.
-  output?: OutputType;
+  output?: string;
 
   // Should optional properties always be enabled
   isOptionalAlwaysEnabled?: boolean;
 }
 
-type OutputType = 'object'|'json'|'string';
 type SupportedLanguage = 'typescript';
-
 
 interface NodeWithDocs extends ts.PropertySignature {
   jsDoc: ts.JSDoc[];
@@ -985,7 +983,8 @@ export function mock(options: Options) {
   if (!fileContents) {
     return {};
   }
-  console.log(fileContents);
+  // remove this from the overall output, maybe wrap in an if with a new arg in options.
+  // console.log(fileContents);
 
   const types = fileContents.reduce((sum, f) => {
     const type = gatherTypes(

--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -40,13 +40,14 @@ export interface Options {
 
   // One of object|json|string. Strings have their object's functions
   // stringified.
-  output?: string;
+  output?: OutputType;
 
   // Should optional properties always be enabled
   isOptionalAlwaysEnabled?: boolean;
 }
 
 type SupportedLanguage = 'typescript';
+export type OutputType = 'object'|'json'|'string';
 
 interface NodeWithDocs extends ts.PropertySignature {
   jsDoc: ts.JSDoc[];
@@ -983,8 +984,6 @@ export function mock(options: Options) {
   if (!fileContents) {
     return {};
   }
-  // remove this from the overall output, maybe wrap in an if with a new arg in options.
-  // console.log(fileContents);
 
   const types = fileContents.reduce((sum, f) => {
     const type = gatherTypes(


### PR DESCRIPTION
### Changes
- added a new arg for the cli `outputFormat` 
- switched console output from `console.dir()` to `console.log()` to get unwrapped json
- removed `console.log(fileContents)` so only json is output to the console.
- switched output from `OutputType` to `string`

### Verify
Run this command to produce a valid json file
```
node ./node_modules/intermock/build/src/cli/index.js \
 --outputFormat json \
 --files ./path/to/my-object.dto.ts \
 --interfaces 'MyObjectDto' \
 > ./fixtures.json
```

### Notes
I ran the formatter and tests, there were no problems from either.
The linter has errors from a couple of test files I didn't touch, I didn't think you'd want me editing them in this PR.