### PR TITLE
More TypeLiteral / Parenthesis support + customFake

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The following TypeScript features are supported:
 - Type aliases
 - Arrays
 - Namespaces
+- Tuples
+- Mapped types
+- Generics
 - Functions (stringified output!)
 - Optional properties
 - Specific [Faker](https://github.com/marak/Faker.js/#api-methods) data types (via JSDoc comment)

--- a/docs/src/main.ts
+++ b/docs/src/main.ts
@@ -18,8 +18,8 @@ import {mock} from '../../src/lang/ts/intermock';
 
 async function setup() {
   const [intermock, monaco] = await Promise.all([
-    import(/* webpackChunkName: "intermock" */ '../../src/index'),
-    import(/* webpackChunkName: "monaco-editor" */ 'monaco-editor'),
+    import(/* webpackChunkName: "intermock" */ '../../src/index') as any,
+    import(/* webpackChunkName: "monaco-editor" */ 'monaco-editor') as any,
   ]);
 
   const initialEditorContent = `interface Admin extends User {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intermock",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Automatically create mock objects and JSON from TypeScript interfaces via Faker",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intermock",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Automatically create mock objects and JSON from TypeScript interfaces via Faker",
   "repository": {
     "type": "git",

--- a/test/ts/test-data/parenthesis.ts
+++ b/test/ts/test-data/parenthesis.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface Secret {
+    message: (string);
+    maybeMessage: (string | boolean);
+    maybeLiterallyMessage: ({ id: string });
+    anotherOne: ({ id: string } | { id: string } | { id: string });
+}
+
+
+export const expectedParens = {
+    Secret: {
+        message: 'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.',
+        maybeMessage: 'Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.',
+        maybeLiterallyMessage: {
+            id: 'bfc8cb62-c6ce-4194-a2a5-499320b837eb',
+        },
+        anotherOne: {
+            id: 'bfc8cb62-c6ce-4194-a2a5-499320b837eb',
+        }
+    },
+};
+  

--- a/test/ts/test-data/typeLiterals.ts
+++ b/test/ts/test-data/typeLiterals.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+interface Person {
+    many: {
+        nested: string;
+        literals: {
+            huh: string;
+        }        
+    };
+}
+
+const strVal = "Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus.";
+
+export const expectedTypeLiterals = {
+    many: {
+        nested: strVal,
+        literals: {
+            huh: strVal,
+        }
+    },
+};
+  


### PR DESCRIPTION
Hi! I dig this repo but it was missing some support I needed for generating fake data from the way our apollo type gen is outputted (specifcally some TypeLiteral and Parenthesis support). Also, some of the data from faker was a little awkward (super long ipsum strings for `id` fields) so I wanted to open up a "customFake" option where you can pass a function that will basically return whatever type of fake you want for your primitives.

I wrote this code a while back and just now decided to try and get the changes pushed to the main project. Let me know your thoughts. Thanks!